### PR TITLE
Wrap content if too long

### DIFF
--- a/_demos/demo4.go
+++ b/_demos/demo4.go
@@ -1,0 +1,62 @@
+// Copyright 2014 The gocui Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+
+	"github.com/jroimartin/gocui"
+)
+
+func layout(g *gocui.Gui) error {
+	maxX, maxY := g.Size()
+	if v, err := g.SetView("main", 1, 1, maxX-1, maxY-1); err != nil {
+		if err != gocui.ErrorUnkView {
+			return err
+		}
+		v.Wrap = true
+		v.WrapPrefix = "> "
+	}
+	return nil
+}
+
+func quit(g *gocui.Gui, v *gocui.View) error {
+	return gocui.ErrorQuit
+}
+
+func main() {
+	var err error
+
+	g := gocui.NewGui()
+	if err := g.Init(); err != nil {
+		log.Panicln(err)
+	}
+	defer g.Close()
+
+	g.SetLayout(layout)
+	if err := g.SetKeybinding("", gocui.KeyCtrlC, 0, quit); err != nil {
+		log.Panicln(err)
+	}
+
+	go func() {
+		var line bytes.Buffer
+		for i := 0; i < 10; i++ {
+			line.WriteString("This is a long line -- ")
+		}
+		fmt.Fprint(g.View("main"), line.String())
+
+		fmt.Fprintln(g.View("main"), "")
+
+		fmt.Fprint(g.View("main"), "Short")
+	}()
+
+	err = g.MainLoop()
+	if err != nil && err != gocui.ErrorQuit {
+		log.Panicln(err)
+	}
+
+}

--- a/view.go
+++ b/view.go
@@ -44,6 +44,13 @@ type View struct {
 
 	// If Frame is true, a border will be drawn around the view
 	Frame bool
+
+	// If Wrap is true, the content that is written to this View is
+	// automatically wrapped when it is longer than its width
+	Wrap bool
+
+	// If Wrap is true, each wrapping line is prefixed with this prefix.
+	WrapPrefix string
 }
 
 // newView returns a new View object.
@@ -179,7 +186,17 @@ func (v *View) draw() error {
 			if j < v.ox {
 				continue
 			}
-			if x >= 0 && x < maxX && y >= 0 && y < maxY {
+			if x == maxX && v.Wrap {
+				x = 0
+				y++
+				for _, p := range v.WrapPrefix {
+					if x == maxX {
+						break
+					}
+					v.setRune(x, y, p)
+					x++
+				}
+			} else if x < maxX && y < maxY {
 				if err := v.setRune(x, y, ch); err != nil {
 					return err
 				}


### PR DESCRIPTION
Continuation of #20 on v0.2-dev.

This was surprisingly straightforward. And, indeed, having the view automatically redraw on resize is wonderful.

Minor caveat: if the prefix is itself bigger than the width of the view, it is not wrapped... which I consider to be ok (this case shouldn't happen _that_ often)
