### PR TITLE
Enabled very basic mouse support

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -42,6 +42,9 @@ type Gui struct {
 
 	// If ShowCursor is true then the cursor is enabled.
 	ShowCursor bool
+
+	// If EnableMouse is true then mouse clicks will be recognized.
+	EnableMouse bool
 }
 
 // NewGui returns a new Gui object.
@@ -212,6 +215,10 @@ func (g *Gui) MainLoop() error {
 
 	termbox.SetInputMode(termbox.InputAlt)
 
+	if g.EnableMouse == true {
+		termbox.SetInputMode(termbox.InputMouse)
+	}
+
 	if err := g.Flush(); err != nil {
 		return err
 	}
@@ -248,7 +255,7 @@ func (g *Gui) consumeevents() error {
 // etc.)
 func (g *Gui) handleEvent(ev *termbox.Event) error {
 	switch ev.Type {
-	case termbox.EventKey:
+	case termbox.EventKey, termbox.EventMouse:
 		return g.onKey(ev)
 	case termbox.EventError:
 		return ev.Err

--- a/keybinding.go
+++ b/keybinding.go
@@ -42,6 +42,10 @@ const (
 	KeyArrowDown      = Key(termbox.KeyArrowDown)
 	KeyArrowLeft      = Key(termbox.KeyArrowLeft)
 	KeyArrowRight     = Key(termbox.KeyArrowRight)
+
+	MouseLeft   = Key(termbox.MouseLeft)
+	MouseMiddle = Key(termbox.MouseMiddle)
+	MouseRight  = Key(termbox.MouseRight)
 )
 
 // Keys combinations.


### PR DESCRIPTION
I see this as work in progress, for now. In terms of the public API, all the
end user has to do is something like g.EnableMouse = true. I think this is
reasonable and may not have to really change. Although I think the way it's
used with KeyBindings should maybe be changed. We need to expose the X and Y of
the click event - I'm not sure if this is possible currently, although Gui has
an unexported event field of type termbox.Event that I believe contains this
information.

Mouse support is something I need for a project I'm using Gocui, I noticed
there was an issue open in relation to this so I figured I'd send back what
I've started already.

Thanks for making gocui - it's awesome.