### PR TITLE
Added support for titles in framed views

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -4,7 +4,8 @@
 
 package gocui
 
-import (
+import
+(
 	"errors"
 
 	"github.com/nsf/termbox-go"
@@ -330,6 +331,11 @@ func (g *Gui) flush() error {
 			if err := g.drawFrame(v); err != nil {
 				return err
 			}
+			if v.Title != "" {
+				if err := g.drawTitle(v); err != nil {
+					return err
+				}
+			}
 		}
 
 		if err := g.draw(v); err != nil {
@@ -376,6 +382,26 @@ func (g *Gui) drawFrame(v *View) error {
 			}
 		}
 	}
+	return nil
+}
+
+// drawTitle draws the title on top of a framed view 2 spaces left
+func (g *Gui) drawTitle(v *View) error {
+	titleMax := len(v.Title)
+	for x := v.x0 + 2; x < v.x1-1 && x < g.maxX; x++ {
+		if x < 0 {
+			continue
+		}
+		if v.y0 > -1 && v.y0 < g.maxY {
+			if (x-v.x0-2) >= 0 && (x-v.x0-2) < titleMax {
+				titleChar := rune(v.Title[x-v.x0-2])
+				if err := g.SetRune(x, v.y0, titleChar/*'x'*/ ); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/view.go
+++ b/view.go
@@ -57,6 +57,9 @@ type View struct {
 	// If Autoscroll is true, the View will automatically scroll down when the
 	// text overflows. If true the view's y-origin will be ignored.
 	Autoscroll bool
+
+	// If te view is framed, allow to show a title on it
+	Title string
 }
 
 type viewLine struct {
@@ -74,6 +77,7 @@ func newView(name string, x0, y0, x1, y1 int) *View {
 		y1:      y1,
 		Frame:   true,
 		tainted: true,
+		Title: "",
 	}
 	return v
 }


### PR DESCRIPTION
This PR add a new attribute "Title" to the views, if it's set to a non-empty string and the view has Frame = true, then the title is shown on the top border (replacing the long dashes). 

IT has a 2 spaces margin, and titles are shortened automatically to fit the space available.

Screenshot:

![screenshot from 2016-02-02 16-03-07](https://cloud.githubusercontent.com/assets/475423/12753327/e1e5aa66-c9c6-11e5-86e5-94be850afbc8.png)


Usage:

```go

	if v, err := g.SetView("example", 2, 2, 30, 30); err != nil {
		if err != gocui.ErrUnknownView {
			return err
		}
		v.Frame = true
		v.Title = "This is a title"
		fmt.Fprintln(v, "Some content here ...")
	}


```