### PR TITLE
Move Editor into View

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -85,7 +85,7 @@ use *Gui.Execute(). For example:
 	})
 
 By default, gocui provides a basic edition mode. This mode can be extended
-and customized creating a new Editor and assigning it to *Gui.Editor:
+and customized creating a new Editor and assigning it to *View.Editor:
 
 	type Editor interface {
 		Edit(v *View, key Key, ch rune, mod Modifier)

--- a/gui.go
+++ b/gui.go
@@ -50,11 +50,6 @@ type Gui struct {
 	// If InputEsc is true, when ESC sequence is in the buffer and it doesn't
 	// match any known sequence, ESC means KeyEsc.
 	InputEsc bool
-
-	// Editor allows to define the editor that manages the edition mode,
-	// including keybindings or cursor behaviour. DefaultEditor is used by
-	// default.
-	Editor Editor
 }
 
 // NewGui returns a new Gui object.
@@ -68,7 +63,6 @@ func NewGui() (*Gui, error) {
 	g.maxX, g.maxY = termbox.Size()
 	g.BgColor, g.FgColor = ColorBlack, ColorWhite
 	g.SelBgColor, g.SelFgColor = ColorBlack, ColorWhite
-	g.Editor = DefaultEditor
 	return g, nil
 }
 
@@ -545,8 +539,8 @@ func (g *Gui) onKey(ev *termbox.Event) error {
 		if matched {
 			break
 		}
-		if g.currentView != nil && g.currentView.Editable && g.Editor != nil {
-			g.Editor.Edit(g.currentView, Key(ev.Key), ev.Ch, Modifier(ev.Mod))
+		if g.currentView != nil && g.currentView.Editable && g.currentView.Editor != nil {
+			g.currentView.Editor.Edit(g.currentView, Key(ev.Key), ev.Ch, Modifier(ev.Mod))
 		}
 	case termbox.EventMouse:
 		mx, my := ev.MouseX, ev.MouseY

--- a/view.go
+++ b/view.go
@@ -41,6 +41,11 @@ type View struct {
 	// buffer at the cursor position.
 	Editable bool
 
+	// Editor allows to define the editor that manages the edition mode,
+	// including keybindings or cursor behaviour. DefaultEditor is used by
+	// default.
+	Editor Editor
+
 	// Overwrite enables or disables the overwrite mode of the view.
 	Overwrite bool
 
@@ -98,6 +103,7 @@ func newView(name string, x0, y0, x1, y1 int) *View {
 		x1:      x1,
 		y1:      y1,
 		Frame:   true,
+		Editor:  DefaultEditor,
 		tainted: true,
 		ei:      newEscapeInterpreter(),
 	}


### PR DESCRIPTION
This change allows to have multiple views with different editors.

For instance, if you are implementing a vim-like editor, you could have some views in normal mode and others in insert mode at the same time. Of course, it is also possible to share the same editor between all of them.