### PR TITLE
Add GetManager method

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -301,6 +301,11 @@ func (g *Gui) SetManager(managers ...Manager) {
 	go func() { g.tbEvents <- termbox.Event{Type: termbox.EventResize} }()
 }
 
+// GetManager gets the current GUI managers.
+func (g *Gui) GetManager() []Manager {
+	return g.managers
+}
+
 // SetManagerFunc sets the given manager function. It deletes all views and
 // keybindings.
 func (g *Gui) SetManagerFunc(manager func(v *Gui) error) {


### PR DESCRIPTION
GetManager method returns the current managers of a Gui.

User case: 
By retrieving the current managers, I was able to encapsulate some behavior in the widget as a method and call this method if the widget is "running". In the bellow example, there is a method to update the widget content, and a go rotine that updates the widget content periodically.

```golang
type Widget struct {}

func (w *Widget) Layout(g *gocui.Gui) (err error) {
	// Create views and keybindings
}

func (w *Widget) Update(g *gocui.Gui) {
	// Update widget content
}

func Update(g *gocui.Gui) {
	for {
		g.Execute(func(g *gocui.Gui) error {
			managers := g.GetManager()
			for _, m := range managers {
				switch w := m.(type) {
				case (*Widget):
					w.Update(g)
				}
			}
			return nil
		})
		time.Sleep(1 * time.Second)
	}
}

func main() {
	g := gocui.NewGui()
	defer g.Close()
	w := new(Widget)
	g.SetManager(w)
	go Update(g)
	g.MainLoop()
}
```