### PR TITLE
Add MouseRelease, MouseWheelUp and MouseWheelDown

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -68,9 +68,12 @@ const (
 	KeyArrowLeft      = Key(termbox.KeyArrowLeft)
 	KeyArrowRight     = Key(termbox.KeyArrowRight)
 
-	MouseLeft   = Key(termbox.MouseLeft)
-	MouseMiddle = Key(termbox.MouseMiddle)
-	MouseRight  = Key(termbox.MouseRight)
+	MouseLeft      = Key(termbox.MouseLeft)
+	MouseMiddle    = Key(termbox.MouseMiddle)
+	MouseRight     = Key(termbox.MouseRight)
+	MouseRelease   = Key(termbox.MouseRelease)
+	MouseWheelUp   = Key(termbox.MouseWheelUp)
+	MouseWheelDown = Key(termbox.MouseWheelDown)
 )
 
 // Keys combinations.


### PR DESCRIPTION
Add support for the following mouse keys:

- MouseRelease
- MouseWheelUp
- MouseWheelDown

```go
	if err := g.SetKeybinding("",
		gocui.MouseWheelUp,
		gocui.ModNone, ScrollUp); err != nil {
		log.Panicln(err)
	}
```