### PR TITLE
Check for collisions in reverse view order

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -184,8 +184,8 @@ func (g *Gui) View(name string) (*View, error) {
 func (g *Gui) ViewByPosition(x, y int) (*View, error) {
 
 	// traverse views in reverse order checking top views first
-	for i := len(g.views) - 1; i > 0; i-- {
-		v := g.views[i]
+	for i := len(g.views); i > 0; i-- {
+		v := g.views[i-1]
 		if x > v.x0 && x < v.x1 && y > v.y0 && y < v.y1 {
 			return v, nil
 		}

--- a/gui.go
+++ b/gui.go
@@ -182,7 +182,10 @@ func (g *Gui) View(name string) (*View, error) {
 // ViewByPosition returns a pointer to a view matching the given position, or
 // error ErrUnknownView if a view in that position does not exist.
 func (g *Gui) ViewByPosition(x, y int) (*View, error) {
-	for _, v := range g.views {
+
+	// traverse views in reverse order checking top views first
+	for i := len(g.views) - 1; i > 0; i-- {
+		v := g.views[i]
 		if x > v.x0 && x < v.x1 && y > v.y0 && y < v.y1 {
 			return v, nil
 		}


### PR DESCRIPTION
I have been developing some code using overlapping views to form a simple dropdown menu system for my program.  I have noticed that the when using mouse clicks the correct view is not identified.

This is because SetViewToTop appends the view to the end of the g.views slice.
However the ViewByPosition checks for matching coordinates from the beginning of the slice. This method is being called from the onKey method here. https://github.com/jroimartin/gocui/blob/master/gui.go#L590

Therefore if you have a large background view, all ViewByPosition calls match the bottom view.

This code reverses the sequence that the views are checked.