### PR TITLE
Bug fix: `View.writeRune` appends stray `\x00` when writing to the end of a line

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -250,23 +250,20 @@ func (v *View) writeRune(x, y int, ch rune) error {
 		v.lines = append(v.lines, s...)
 	}
 
-	olen := len(v.lines[y])
 	if x >= len(v.lines[y]) {
 		s := make([]cell, x-len(v.lines[y])+1)
 		v.lines[y] = append(v.lines[y], s...)
-	}
-
-	c := cell{
-		fgColor: v.FgColor,
-		bgColor: v.BgColor,
-	}
-	if !v.Overwrite || (v.Overwrite && x >= olen-1) {
-		c.chr = '\x00'
-		v.lines[y] = append(v.lines[y], c)
+	} else if !v.Overwrite {
+		v.lines[y] = append(v.lines[y], cell{})
 		copy(v.lines[y][x+1:], v.lines[y][x:])
 	}
-	c.chr = ch
-	v.lines[y][x] = c
+
+	v.lines[y][x] = cell{
+		fgColor: v.FgColor,
+		bgColor: v.BgColor,
+		chr:     ch,
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The cause was that the line array was extended twice when writing at the end of
a line - once in the first `if` clause because the cursor is beyond the end of
the line, and then again in the second `if` clause dealing with the `Overwrite`
condition.

This change makes the two `if` clauses mutually exclusive.

Please let me know what you think or if you'd like me to make any changes.