### PR TITLE
Bug fix: `v.MoveCursor` with dx < -1 or dx > 1 does not work if origin needs to be adjusted

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -4,7 +4,9 @@
 
 package gocui
 
-import "errors"
+import (
+	"errors"
+)
 
 const maxInt = int(^uint(0) >> 1)
 
@@ -185,7 +187,8 @@ func (v *View) MoveCursor(dx, dy int, writeMode bool) {
 		}
 	} else if cx < 0 {
 		if !v.Wrap && v.ox > 0 { // move origin to the left
-			v.ox--
+			v.ox += cx
+			v.cx = 0
 		} else { // move to previous line
 			if prevLineWidth > 0 {
 				if !v.Wrap { // set origin so the EOL is visible
@@ -210,7 +213,8 @@ func (v *View) MoveCursor(dx, dy int, writeMode bool) {
 			v.cx = cx
 		} else {
 			if cx >= maxX {
-				v.ox++
+				v.ox += cx - maxX + 1
+				v.cx = maxX
 			} else {
 				v.cx = cx
 			}


### PR DESCRIPTION
The existing logic moves the origin by 1 in either direction. The new logic adjusts the origin by the appropriate amount, and moves the cursor to the beginning or end of the line.

Please let me know what you think or if you'd like me to make any changes.