### PR TITLE
Expose number of lines in view buffer

### DIFF
--- a/view.go
+++ b/view.go
@@ -477,3 +477,8 @@ func (v *View) Word(x, y int) (string, error) {
 func indexFunc(r rune) bool {
 	return r == ' ' || r == 0
 }
+
+// NumLines returns the number of lines in the view's buffer.
+func (v *View) NumLines() int {
+	return len(v.lines)
+}


### PR DESCRIPTION
This commit adds a trivial function to expose the number of lines currently in the view buffer. This is useful to do things like not scroll past the end of the buffer, scroll to show exactly the tail of the buffer filling the view, etc..