### PR TITLE
Add BufferLines and ViewBufferLines func to View

### DIFF
--- a/view.go
+++ b/view.go
@@ -430,6 +430,18 @@ func (v *View) Buffer() string {
 	return strings.Replace(str, "\x00", " ", -1)
 }
 
+// ViewBufferLines returns the lines in the view's internal
+// buffer that is shown to the user.
+func (v *View) ViewBufferLines() []string {
+	lines := make([]string, len(v.viewLines))
+	for i, l := range v.viewLines {
+		str := lineType(l.line).String()
+		str = strings.Replace(str, "\x00", " ", -1)
+		lines[i] = str
+	}
+	return lines
+}
+
 // ViewBuffer returns a string with the contents of the view's buffer that is
 // shown to the user.
 func (v *View) ViewBuffer() string {

--- a/view.go
+++ b/view.go
@@ -408,6 +408,18 @@ func (v *View) clearRunes() {
 	}
 }
 
+// BufferLines returns the lines in the view's internal
+// buffer.
+func (v *View) BufferLines() []string {
+	lines := make([]string, len(v.lines))
+	for i, l := range v.lines {
+		str := lineType(l).String()
+		str = strings.Replace(str, "\x00", " ", -1)
+		lines[i] = str
+	}
+	return lines
+}
+
 // Buffer returns a string with the contents of the view's internal
 // buffer.
 func (v *View) Buffer() string {


### PR DESCRIPTION
# What is the problem this PR tries to solve?
Many times you want to operate on the individual lines of a View. Example use cases: 
- Scrolling
- Calculating good Cursor position when the buffer changes
- Manual cursor movement

Currently, the `Buffer` function returns a concatenated string, that has to be split to use the individual lines. It's unnecessary wasting of computational resource.

# How this PR solves the problem?
By returning individual lines as strings in an array, you don't have to split the string. 

# How to manually test this?
For an existing use case try the new `BufferLines` or `ViewBufferLines`  function.

# Risk
None that I know of.