### PR TITLE
adds jsonui to projects using gocui

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,6 @@ func quit(g *gocui.Gui, v *gocui.View) error {
 * [terminews](http://github.com/antavelos/terminews): Terminal based RSS reader.
 * [diagram](https://github.com/esimov/diagram): Tool to convert ascii arts into hand drawn diagrams.
 * [pody](https://github.com/JulienBreux/pody): CLI app to manage Pods in a Kubernetes cluster.
+* [jsonui](https://github.com/gulyasm/jsonui): Interactive JSON explorer for your terminal
 
 Note: if your project is not listed here, let us know! :)


### PR DESCRIPTION
# What is the problem this PR tries to solve?
[jsonui](https://github.com/gulyasm/jsonui) is proudly using gocui, but was not listed on the gocui README file

# How this PR solves the problem?
By adding jsonui to the README file.

# How to manually test this?
Check on github preview tab.

# Risk
None