### PR TITLE
unselect view when there is no matching name in *Gui.SetCurrnetView()

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -234,6 +234,7 @@ func (g *Gui) SetCurrentView(name string) (*View, error) {
 			return v, nil
 		}
 	}
+	g.currentView = nil
 	return nil, ErrUnknownView
 }
 


### PR DESCRIPTION
Wanted don't select any view when there is no matching name in 
`*Gui.SetCurrentView()`
like just passing empty string for view name.