### PR TITLE
Fix long paste bug in DefaultEditor

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -208,7 +208,12 @@ func (v *View) MoveCursor(dx, dy int, writeMode bool) {
 			v.cx = cx
 		} else {
 			if cx >= maxX {
-				v.ox += cx - maxX + 1
+				v.ox += cx - maxX
+				// if we're not editing, move the origin one extra space to facilitate
+				// scrolling to the right
+				if !writeMode {
+					v.ox++
+				}
 				v.cx = maxX
 			} else {
 				v.cx = cx


### PR DESCRIPTION
If you had an editable view with the DefaultEditor and you pasted input that was longer (horizontally) than the width of the view, this logic used to insert an extra space between each character after the edge of the view.

This code demonstrates the bug:
```
package main

import (
	"log"

	"github.com/jroimartin/gocui"
)

func main() {
	g, err := gocui.NewGui(gocui.OutputNormal)
	if err != nil {
		log.Panicln(err)
	}
	defer g.Close()

	g.Cursor = true
	g.SetManagerFunc(layout)

	if err := g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
		log.Panicln(err)
	}

	if err := g.MainLoop(); err != nil && err != gocui.ErrQuit {
		log.Panicln(err)
	}
}

func layout(g *gocui.Gui) error {
	maxX, maxY := g.Size()
	if v, err := g.SetView("hello", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2); err != nil {
		if err != gocui.ErrUnknownView {
			return err
		}
		v.Editable = true
		v.Editor = gocui.DefaultEditor
		g.SetCurrentView("hello")
	}
	return nil
}

func quit(g *gocui.Gui, v *gocui.View) error {
	return gocui.ErrQuit
}
```

If you paste a thing longer than 7 characters into that view, it will end up with spaces in the view that you never typed. This PR suppresses that behavior.

However, I'm not completely convinced that I'm fixing this the *right* way. I'd be happy to change my approach if this isn't the way to go.