### PR TITLE
Fix pasting long lines: flush after each consumed event

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -4,7 +4,9 @@
 
 package gocui
 
-import "errors"
+import (
+	"errors"
+)
 
 const maxInt = int(^uint(0) >> 1)
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/hassansin/gocui
+
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=

--- a/gui.go
+++ b/gui.go
@@ -7,7 +7,7 @@ package gocui
 import (
 	"errors"
 
-	"github.com/nsf/termbox-go"
+	termbox "github.com/nsf/termbox-go"
 )
 
 var (
@@ -401,6 +401,9 @@ func (g *Gui) consumeevents() error {
 			}
 		default:
 			return nil
+		}
+		if err := g.flush(); err != nil {
+			return err
 		}
 	}
 }

--- a/gui.go
+++ b/gui.go
@@ -570,7 +570,7 @@ func (g *Gui) draw(v *View) error {
 
 			gMaxX, gMaxY := g.Size()
 			cx, cy := curview.x0+curview.cx+1, curview.y0+curview.cy+1
-			if cx >= 0 && cx < gMaxX && cy >= 0 && cy < gMaxY {
+			if cx >= 0 && cx < gMaxX && cy >= 0 && cy < gMaxY && !curview.HideCursor {
 				termbox.SetCursor(cx, cy)
 			} else {
 				termbox.HideCursor()

--- a/view.go
+++ b/view.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/nsf/termbox-go"
+	termbox "github.com/nsf/termbox-go"
 )
 
 // A View is a window. It maintains its own internal buffer and cursor

--- a/view.go
+++ b/view.go
@@ -71,6 +71,8 @@ type View struct {
 	// If Mask is true, the View will display the mask instead of the real
 	// content
 	Mask rune
+
+	HideCursor bool
 }
 
 type viewLine struct {
@@ -354,6 +356,14 @@ func (v *View) draw() error {
 				return err
 			}
 			x++
+		}
+		//highlight rest of the line
+		if v.Highlight {
+			for i := len(vline.line); i < maxX; i++ {
+				if err := v.setRune(i, y, ' ', v.FgColor, v.BgColor); err != nil {
+					return err
+				}
+			}
 		}
 		y++
 	}

--- a/view.go
+++ b/view.go
@@ -197,6 +197,11 @@ func (v *View) Origin() (x, y int) {
 	return v.ox, v.oy
 }
 
+//Coordinates returns view co-ordintaes
+func (v *View) Coordinates() (int, int, int, int) {
+	return v.x0, v.y0, v.x1, v.y1
+}
+
 // Write appends a byte slice into the view's internal buffer. Because
 // View implements the io.Writer interface, it can be passed as parameter
 // of functions like fmt.Fprintf, fmt.Fprintln, io.Copy, etc. Clear must


### PR DESCRIPTION
Needed to flush after each consumed event. Flushing would redraw the screen which in turn fixes cursor coordinates. Fixes #187