### PR TITLE
Calling clear panics if the cursor position is outside the resized wi…

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -420,6 +420,7 @@ func (g *Gui) handleEvent(ev *termbox.Event) error {
 
 // flush updates the gui, re-drawing frames and buffers.
 func (g *Gui) flush() error {
+	termbox.HideCursor()
 	termbox.Clear(termbox.Attribute(g.FgColor), termbox.Attribute(g.BgColor))
 
 	maxX, maxY := termbox.Size()


### PR DESCRIPTION
…ndow

Hide the cursor before calling Clear()

See nsf/termbox-go#125