### PR TITLE
Change edition mode to editing mode in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Minimalist Go package aimed at creating Console User Interfaces.
 * Global and view-level keybindings.
 * Mouse support.
 * Colored text.
-* Customizable edition mode.
+* Customizable editing mode.
 * Easy to build reusable widgets, complex layouts...
 
 ## Installation

--- a/doc.go
+++ b/doc.go
@@ -84,7 +84,7 @@ use *Gui.Update(). For example:
 		return nil
 	})
 
-By default, gocui provides a basic edition mode. This mode can be extended
+By default, gocui provides a basic editing mode. This mode can be extended
 and customized creating a new Editor and assigning it to *View.Editor:
 
 	type Editor interface {

--- a/view.go
+++ b/view.go
@@ -41,7 +41,7 @@ type View struct {
 	// buffer at the cursor position.
 	Editable bool
 
-	// Editor allows to define the editor that manages the edition mode,
+	// Editor allows to define the editor that manages the editing mode,
 	// including keybindings or cursor behaviour. DefaultEditor is used by
 	// default.
 	Editor Editor


### PR DESCRIPTION
I think an `edition` refers to a version of some published material. If I understood the intent of the documentation correctly, perhaps it should be `editing mode` or simply `edit mode`.