### PR TITLE
Add lazygit to list of projects using gocui

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,6 @@ func quit(g *gocui.Gui, v *gocui.View) error {
 * [fac](https://github.com/mkchoi212/fac): git merge conflict resolver
 * [jsonui](https://github.com/gulyasm/jsonui): Interactive JSON explorer for your terminal.
 * [cointop](https://github.com/miguelmota/cointop): Interactive terminal based UI application for tracking cryptocurrencies.
+* [lazygit](https://github.com/jesseduffield/lazygit): Simple terminal UI for git commands.
 
 Note: if your project is not listed here, let us know! :)


### PR DESCRIPTION
That it! Add [lazygit](https://github.com/jesseduffield/lazygit) to list of projects using gocui